### PR TITLE
Add Grid to Histogram for Better Readability

### DIFF
--- a/Marina-Mendes_Schizophrenia-fMRI.ipynb
+++ b/Marina-Mendes_Schizophrenia-fMRI.ipynb
@@ -130,7 +130,7 @@
     "plt.xlabel(\"Voxel Intensity Values\")\n",
     "plt.ylabel(\"Frequency\")\n",
     "plt.tight_layout() #This one is optional, only for improving the layout\n",
-    "plt.grid(alpha=0.4)  # Add a light grid for better readability\n",
+    "plt.grid(alpha=0.3)  # Add a light grid for better readability\n",
     "plt.show()"
    ]
   },

--- a/Marina-Mendes_Schizophrenia-fMRI.ipynb
+++ b/Marina-Mendes_Schizophrenia-fMRI.ipynb
@@ -130,7 +130,7 @@
     "plt.xlabel(\"Voxel Intensity Values\")\n",
     "plt.ylabel(\"Frequency\")\n",
     "plt.tight_layout() #This one is optional, only for improving the layout\n",
-    "plt.grid(alpha=0.3)  # Add a light grid for better readability\n",
+    "plt.grid(alpha=0.4)  # Add a light grid for better readability\n",
     "plt.show()"
    ]
   },

--- a/Marina-Mendes_Schizophrenia-fMRI.ipynb
+++ b/Marina-Mendes_Schizophrenia-fMRI.ipynb
@@ -130,7 +130,7 @@
     "plt.xlabel(\"Voxel Intensity Values\")\n",
     "plt.ylabel(\"Frequency\")\n",
     "plt.tight_layout() #This one is optional, only for improving the layout\n",
-    "\n",
+    "plt.grid(alpha=0.4)  # Add a light grid for better readability\n",
     "plt.show()"
    ]
   },
@@ -159,7 +159,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "home_assignment",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Dear Marina 

I wanted to congratulate you on the well-documented and organized approach to the brain imaging analysis for schizophrenia! The code is clear and easy to follow, and the use of visualizations adds great value to the analysis.
I noticed that the histogram could benefit from a grid to enhance readability, especially when interpreting the data visually. Adding a grid makes it easier to follow the distribution of voxel intensity values and identify key data points.

Let me know if you have any further suggestions or thoughts!

cheers, 
Bita